### PR TITLE
Reverting links to absolute paths

### DIFF
--- a/fuel/app/views/companytemplate.php
+++ b/fuel/app/views/companytemplate.php
@@ -21,9 +21,9 @@
     <div class="links">
         <nav>
             <ol>
-                <li><a href="./index">HOME</a></li>
-                <li><a href="./colors.php">COLORS</a></li>
-                <li><a href="./about.php">ABOUT</a></li>
+                <li><a href="https://cs.colostate.edu:4444/~ewolving/m1/index/company/index">HOME</a></li>
+                <li><a href="https://cs.colostate.edu:4444/~ewolving/m1/index/company/colors">COLORS</a></li>
+                <li><a href="https://cs.colostate.edu:4444/~ewolving/m1/index/company/about">ABOUT</a></li>
                 <li><a href="https://en.wikipedia.org/wiki/Chuckwalla" alt="wikipedia page">CHUCKWALLA INFO</a></li>
             </ol> 
         </nav>


### PR DESCRIPTION
The ~eid/m1 redirect completely breaks the relative links. Absolute links make sure it stays functional