### PR TITLE
Add additional table styling from chuckwalla.css

### DIFF
--- a/local_html/m1/assets/css/printview.css
+++ b/local_html/m1/assets/css/printview.css
@@ -32,10 +32,38 @@ table.colors {
     visibility: visible;
     position: absolute;
     top: 200px;
+    border: 1px solid;
+    border-collapse: collapse;
+    width: 50%;
 }
 
 table.square-table {
     visibility: visible;
     position: absolute;
     top: 500px;
+    width: 50%;
+    border-collapse: collapse;
+}
+
+
+table.colors caption {
+    border: 1px solid;
+}
+
+table.colors td {
+    border: 1px solid;
+    padding: 5px;
+}
+
+table.colors td.col-one {
+    width: 20%;
+}
+
+table.colors td.col-two {
+    width: 80%;
+}
+
+table.square-table td {
+    border: 1px solid;
+    padding: 5px;
 }


### PR DESCRIPTION
Styles the tables in the print view to match their appearance on the main colors page. The CSS additions here are directly from chuckwalla.css