### PR TITLE
Add a line to the template which links JS

### DIFF
--- a/fuel/app/views/companytemplate.php
+++ b/fuel/app/views/companytemplate.php
@@ -7,6 +7,7 @@
     <meta name="description" content="Chuckwalla Corp M1">
     <!-- <?php echo Asset::css($css) ?> putting this here has no effect -->
     <?php echo Asset::css($css) ?>
+    <?php echo Asset::js($js) ?>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,400;0,700;1,400&family=Rubik:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">


### PR DESCRIPTION
This was seemingly missed in the pull request to add chuckwalla.js and default.js - this line is necessary for the colors page to use the JS we have.