### PR TITLE
Fix event listener generation

### DIFF
--- a/local_html/m1/assets/js/chuckwalla.js
+++ b/local_html/m1/assets/js/chuckwalla.js
@@ -14,7 +14,7 @@ window.onload = function(){
             //checkForDuplicates(rowsUnderConsideration[i]); Also broken sad days
         }
 
-        for(let i = 0; i<numRows; i++){
+        for(let i = 0; i<numColumns; i++){
             for(let j = 0; j < numColumns; j++){
                 const currentId = "" + alphabet[j] + i;
                 bigTableEventListeners(currentId);


### PR DESCRIPTION
JS now generates an event listener for every row of cells instead of only for the first (number of colors) rows. Squares are a difficult concept :(